### PR TITLE
Add infrastructure for migrating one mdes version to other. #3623

### DIFF
--- a/lib/mdes_version.rb
+++ b/lib/mdes_version.rb
@@ -1,50 +1,71 @@
 class MdesVersion
-##
-# Set the MDES version for a new deployment.
-#
-# @param [String] new_number
-def self.set!(new_number)
-  fail 'MDES version cannot be blank.' if new_number.blank?
+  ##
+  # Set the MDES version for a new deployment.
+  #
+  # @param [String] new_number
+  def self.set!(new_number)
+    fail 'MDES version cannot be blank.' if new_number.blank?
 
-  ActiveRecord::Base.connection.tap do |conn|
-    current = conn.select_one('SELECT number FROM mdes_version')
-    if current
-      if current['number'] != new_number
-        raise "This deployment already has an MDES version (#{current['number']}). Upgrades aren't implemented yet (#2090)."
+    ActiveRecord::Base.connection.tap do |conn|
+      current = conn.select_one('SELECT number FROM mdes_version')
+      if current
+        if current['number'] != new_number
+          raise "This deployment already has an MDES version (#{current['number']}). Use a migrator to change MDES versions."
+        end
+      else
+        conn.execute("INSERT INTO mdes_version (number) VALUES (%s)" % conn.quote(new_number))
       end
-    else
-      conn.execute("INSERT INTO mdes_version (number) VALUES (%s)" % conn.quote(new_number))
     end
   end
-end
 
-def initialize(number=nil)
-  @number = number
-end
+  ##
+  # Change the MDES version for a deployment.
+  #
+  # This is intended to be called from a migration only, in conjunction with
+  # making whatever changes are necessary to semantically change the deployed
+  # version.
+  #
+  # @see VersionMigrator
+  def self.change!(new_number)
+    fail 'MDES version cannot be blank.' if new_number.blank?
 
-##
-# @return [String] the current configured version number. If none has been
-#   configured, it throws an exception.
-def number
-  @number ||= begin
-    result = ActiveRecord::Base.connection.select_one('SELECT number FROM mdes_version')
-
-    if result
-      result['number']
-    else
-      fail 'No MDES version set for this deployment yet.'
+    ActiveRecord::Base.connection.tap do |conn|
+      current = conn.select_one('SELECT number FROM mdes_version')
+      if current
+        conn.execute("UPDATE mdes_version SET number=%s" % conn.quote(new_number))
+      else
+        raise "No MDES version set for this deployment yet."
+      end
     end
   end
-end
 
-##
-# @return [NcsNavigator::Mdes::Specification] a memoized specification for
-#   the current number.
-def specification
-  @specification ||= NcsNavigator::Mdes(number)
-end
-
-def specification=(spec)
-  @specification = spec
-end
+  def initialize(number=nil)
+    @number = number
   end
+
+  ##
+  # @return [String] the current configured version number. If none has been
+  #   configured, it throws an exception.
+  def number
+    @number ||= begin
+      result = ActiveRecord::Base.connection.select_one('SELECT number FROM mdes_version')
+
+      if result
+        result['number']
+      else
+        fail 'No MDES version set for this deployment yet.'
+      end
+    end
+  end
+
+  ##
+  # @return [NcsNavigator::Mdes::Specification] a memoized specification for
+  #   the current number.
+  def specification
+    @specification ||= NcsNavigator::Mdes(number)
+  end
+
+  def specification=(spec)
+    @specification = spec
+  end
+end

--- a/lib/ncs_navigator/staff_portal/mdes.rb
+++ b/lib/ncs_navigator/staff_portal/mdes.rb
@@ -1,0 +1,7 @@
+require 'ncs_navigator/staff_portal'
+
+module NcsNavigator::staff_portal
+  module Mdes
+    autoload :VersionMigrator, 'ncs_navigator/staff_portal/mdes/version_migrator'
+  end
+end

--- a/lib/ncs_navigator/staff_portal/mdes.rb
+++ b/lib/ncs_navigator/staff_portal/mdes.rb
@@ -1,7 +1,8 @@
 require 'ncs_navigator/staff_portal'
 
-module NcsNavigator::staff_portal
+module NcsNavigator::StaffPortal
   module Mdes
-    autoload :VersionMigrator, 'ncs_navigator/staff_portal/mdes/version_migrator'
+    autoload :VersionMigrator,   		'ncs_navigator/staff_portal/mdes/version_migrator'
+    autoload :VersionMigrations, 		'ncs_navigator/staff_portal/mdes/version_migrations'
   end
 end

--- a/lib/ncs_navigator/staff_portal/mdes/version_migrations.rb
+++ b/lib/ncs_navigator/staff_portal/mdes/version_migrations.rb
@@ -1,0 +1,7 @@
+require 'ncs_navigator/staff_portal'
+
+module NcsNavigator::StaffPortal::Mdes
+  module VersionMigrations
+    autoload :Basic, 'ncs_navigator/staff_portal/mdes/version_migrations/basic'
+  end
+end

--- a/lib/ncs_navigator/staff_portal/mdes/version_migrations/basic.rb
+++ b/lib/ncs_navigator/staff_portal/mdes/version_migrations/basic.rb
@@ -1,0 +1,43 @@
+require 'ncs_navigator/staff_portal'
+
+module NcsNavigator::StaffPortal::Mdes::VersionMigrations
+  ##
+  # A migrator that does the minimum steps that are required for any version
+  # change:
+  #
+  # * Change the code lists to the ones for the new version
+  # * Change the stored version number to the new version
+  #
+  # N.b.: using this migration for a pair of versions is a claim that there are
+  # NO semantic modifications of specified values between them. DO NOT use it
+  # for any pair of versions without rigorously verifying that this is the case.
+  #
+  # @see VersionMigrator
+  class Basic
+    attr_reader :from, :to
+
+    def initialize(from_version, to_version)
+      @from = from_version
+      @to = to_version
+    end
+
+    def run
+      ActiveRecord::Base.transaction do
+        switch_code_lists
+        change_registered_version
+      end
+    end
+
+    def switch_code_lists
+      NcsNavigator::StaffPortal::MdesCodeListLoader.
+        new(:mdes_version => to, :interactive => true).
+        load_from_yaml
+    end
+    protected :switch_code_lists
+
+    def change_registered_version
+      MdesVersion.change!(to)
+    end
+    protected :change_registered_version
+  end
+end

--- a/lib/ncs_navigator/staff_portal/mdes/version_migrations/basic.rb
+++ b/lib/ncs_navigator/staff_portal/mdes/version_migrations/basic.rb
@@ -16,9 +16,10 @@ module NcsNavigator::StaffPortal::Mdes::VersionMigrations
   class Basic
     attr_reader :from, :to
 
-    def initialize(from_version, to_version)
+    def initialize(from_version, to_version, options={})
       @from = from_version
       @to = to_version
+      @interactive = options[:interactive]
     end
 
     def run
@@ -30,7 +31,7 @@ module NcsNavigator::StaffPortal::Mdes::VersionMigrations
 
     def switch_code_lists
       NcsNavigator::StaffPortal::MdesCodeListLoader.
-        new(:mdes_version => to, :interactive => true).
+        new(:mdes_version => to, :interactive => @interactive).
         load_from_yaml
     end
     protected :switch_code_lists

--- a/lib/ncs_navigator/staff_portal/mdes/version_migrator.rb
+++ b/lib/ncs_navigator/staff_portal/mdes/version_migrator.rb
@@ -16,15 +16,23 @@ module NcsNavigator::StaffPortal::Mdes
     # - #from: the version this migration expects Ops to be in before it
     #   starts executing.
     # - #to: the version this migration will leave Ops in after #run is complete.
-    KNOWN_MIGRATIONS = [
-    ]
+    #
+    # @return [Array<#run,#to#from>]
+    def self.default_migrations(options={})
+      [
+        # No semantic differences 3.0 -> 3.2
+        VersionMigrations::Basic.new('3.0', '3.2', options)
+      ]
+    end
 
     attr_reader :start_version, :known_migrations
 
     def initialize(options={})
-      @start_version = options.delete(:start_version) || StaffPortal.mdes_version.number
-      @known_migrations = options.delete(:known_migrations) || KNOWN_MIGRATIONS
       @interactive = options.delete(:interactive)
+      @start_version = options.delete(:start_version) ||
+        StaffPortal.mdes_version.number
+      @known_migrations = options.delete(:known_migrations) ||
+        self.class.default_migrations(:interactive => @interactive)
     end
 
     ##
@@ -82,9 +90,12 @@ module NcsNavigator::StaffPortal::Mdes
       end
 
       all.each do |migration|
-        $stderr.print "Migrating from #{migration.from} to #{migration.to}..." if interactive?
+        $stderr.puts "Migrating from #{migration.from} to #{migration.to}." if interactive?
         migration.run
-        $stderr.puts "done." if interactive?
+      end
+
+      if interactive?
+        $stderr.puts "MDES version migration complete. Registered MDES version for this deployment is now #{MdesVersion.new.number}."
       end
     end
   end

--- a/lib/ncs_navigator/staff_portal/mdes/version_migrator.rb
+++ b/lib/ncs_navigator/staff_portal/mdes/version_migrator.rb
@@ -1,0 +1,91 @@
+module NcsNavigator::StaffPortal::Mdes
+  ##
+  # The component which takes an existing Ops deployment and safely
+  # updates its MDES version. This may involve stepwise migration through
+  # several intermediate versions.
+  class VersionMigrator
+    ##
+    # The objects registered here migrate Ops from one MDES version to the
+    # an adjacent one. Each migration object must implement three methods:
+    #
+    # - #run: the method that actually performs the migration. It must do
+    #   everything that's required to safely change Ops from one version to
+    #   the next. In addition to whatever version-specific migrations are
+    #   required, this includes changing the stored MDES version value and
+    #   updating the code lists.
+    # - #from: the version this migration expects Ops to be in before it
+    #   starts executing.
+    # - #to: the version this migration will leave Ops in after #run is complete.
+    KNOWN_MIGRATIONS = [
+    ]
+
+    attr_reader :start_version, :known_migrations
+
+    def initialize(options={})
+      @start_version = options.delete(:start_version) || StaffPortal.mdes_version.number
+      @known_migrations = options.delete(:known_migrations) || KNOWN_MIGRATIONS
+      @interactive = options.delete(:interactive)
+    end
+
+    ##
+    # Returns the chain of migration instances which take the system from
+    # {#start_version} to {target_version}. If no chain can be determined
+    # it throws an exception.
+    #
+    # @param [String] target_version
+    # @return [Array<#to,#from,#run>] the migrations to use
+    def migrations(target_version)
+      unless known_migrations.collect(&:to).include?(target_version)
+        fail "There is no migration path to #{target_version} from any version."
+      end
+      unless known_migrations.collect(&:from).include?(start_version)
+        fail "There is no migration path from #{start_version} to any version."
+      end
+
+      best_path = migration_paths(start_version, target_version).
+        sort_by { |path| path.size }.
+        first
+
+      best_path or fail "There is no migration path from #{start_version} to #{target_version}."
+    end
+
+    def migration_paths(from, to)
+      if sole_migration = known_migrations.find { |m| m.to == to && m.from == from }
+        return [[sole_migration]]
+      end
+
+      known_migrations.
+        select { |m| m.from == from }.
+        each_with_object([]) { |m, acc| acc.concat(migration_paths(m.to, to).reject { |sub| sub.empty? }.collect { |sub| [m] + sub }) }.
+        select { |path| path.last.try(:to) == to }
+    end
+    private :migration_paths
+
+    def interactive?
+      @interactive
+    end
+    private :interactive?
+
+    ##
+    # Determines the appropriate migrations to execute, then executes them.
+    # Throws an exception if no path from {#start_version} to {target_version}.
+    #
+    # @return [void]
+    def migrate!(target_version)
+      all = migrations(target_version)
+
+      if interactive?
+        steps = [start_version] + migrations(target_version).collect(&:to)
+        if steps.size > 2
+          $stderr.puts "Migrating from #{steps.first} to #{steps.last} via #{steps[1,steps.size - 2].join(', ')}"
+        end
+      end
+
+      all.each do |migration|
+        $stderr.print "Migrating from #{migration.from} to #{migration.to}..." if interactive?
+        migration.run
+        $stderr.puts "done." if interactive?
+      end
+    end
+  end
+end

--- a/lib/ncs_navigator/staff_portal/mdes_code_list_loader.rb
+++ b/lib/ncs_navigator/staff_portal/mdes_code_list_loader.rb
@@ -80,7 +80,7 @@ module NcsNavigator::StaffPortal
 
         partitioned[:delete].each do |entry|
           do_update(
-            %Q(DELETE FROM ncs_codes WHERE local_code=%s AND list_name='%s'),
+            %Q(DELETE FROM ncs_codes WHERE local_code=? AND list_name=?),
             %w(local_code list_name).collect { |k| entry[k] })
         end
       end

--- a/lib/tasks/mdes.rake
+++ b/lib/tasks/mdes.rake
@@ -64,7 +64,7 @@ namespace :mdes do
   namespace :version do
     desc 'Print the current MDES version'
     task :show => :environment do
-      puts "Current MDES version is #{StaffPortal.mdes.mdes_version}."
+      puts "Current MDES version is #{StaffPortal.mdes.version}."
     end
 
     desc 'Set the MDES version in a new deployment'

--- a/lib/tasks/mdes.rake
+++ b/lib/tasks/mdes.rake
@@ -71,6 +71,13 @@ namespace :mdes do
     task :set, [:version] => [:environment] do |t, args|
       MdesVersion.set!(args[:version])
     end
+
+    desc 'Convert this instance to the named MDES version'
+    task :migrate, [:to_version] => [:environment] do |t, args|
+      fail "Please specify :to_version" unless args[:to_version]
+      NcsNavigator::StaffPortal::Mdes::VersionMigrator.
+        new(:interactive => true).migrate!(args[:to_version])
+    end
   end
 end
 

--- a/spec/lib/mdes_version_spec.rb
+++ b/spec/lib/mdes_version_spec.rb
@@ -68,11 +68,29 @@ describe MdesVersion do
 
       it 'throws an exception if the new version is different' do
         expect { MdesVersion.set!('2.1') }.
-          should raise_error(/This deployment already has an MDES version \(2\.0\)\. Upgrades aren't implemented yet \(#2090\)\./)
+          should raise_error(/This deployment already has an MDES version \(2\.0\)\. Use a migrator to change MDES versions\./)
       end
 
       it 'does nothing if the new version is the same' do
         expect { MdesVersion.set!('2.0') }.should_not raise_error
+      end
+    end
+    describe '.change!' do
+      it 'fails if changed to nil' do
+        expect { MdesVersion.change!(nil) }.should raise_error(/MDES version cannot be blank./)
+      end
+
+      it 'fails if no version is set' do
+        remove_db_version_number
+
+        expect { MdesVersion.change!('3.0') }.to raise_error('No MDES version set for this deployment yet.')
+      end
+
+      it 'when a version is already set it changes the version' do
+        set_db_version_number '2.0'
+
+        MdesVersion.change!('2.1')
+        MdesVersion.new.number.should == '2.1'
       end
     end
   end

--- a/spec/lib/ncs_navigator/staff_portal/mdes/version_migrations/basic_spec.rb
+++ b/spec/lib/ncs_navigator/staff_portal/mdes/version_migrations/basic_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+module NcsNavigator::StaffPortal::Mdes::VersionMigrations
+  describe Basic do
+    let(:migrator) { Basic.new(StaffPortal.mdes_version.number, '2.2') }
+
+    describe '#initialize' do
+      it 'sets #from' do
+        migrator.from.should == StaffPortal.mdes_version.number
+      end
+
+      it 'sets #to' do
+        migrator.to.should == '2.2'
+      end
+    end
+
+    describe '#run' do
+      before do
+        MdesVersion.set!(migrator.from)
+        migrator.run
+      end
+
+      after do
+        # restore the code list to the current version
+        NcsNavigator::StaffPortal::MdesCodeListLoader.new.load_from_yaml
+      end
+
+      it 'updates the MDES version in the database' do
+        MdesVersion.new.number.should == migrator.to
+      end
+
+      let(:target_version_code_lists) {
+        NcsNavigator::Mdes(migrator.to).types.
+          select { |vt| vt.code_list }.collect { |vt| vt.name.upcase }.sort
+      }
+
+      def select_one_column(query)
+        ActiveRecord::Base.connection.select_all(query).
+          collect { |row| row.values.first }
+      end
+
+      it "changes the code lists to the targeted version's lists" do
+        select_one_column("SELECT DISTINCT list_name FROM ncs_codes ORDER BY list_name").
+          should == target_version_code_lists
+      end
+    end
+  end
+end

--- a/spec/lib/ncs_navigator/staff_portal/mdes/version_migrator_spec.rb
+++ b/spec/lib/ncs_navigator/staff_portal/mdes/version_migrator_spec.rb
@@ -30,8 +30,11 @@ module NcsNavigator::StaffPortal::Mdes
             known_migrations.collect(&:from).should == %w(3 tacos)
         end
 
-        it 'defaults to the KNOWN_MIGRATIONS constant' do
-          VersionMigrator.new.known_migrations.should be(VersionMigrator::KNOWN_MIGRATIONS)
+        it 'defaults to the list returned by .default_migrations' do
+          expected_defaults = VersionMigrator.default_migrations.collect { |m| [m.from, m.to] }
+          actual_defaults = VersionMigrator.new.known_migrations.collect { |m| [m.from, m.to] }
+
+          actual_defaults.should == expected_defaults
         end
       end
     end

--- a/spec/lib/ncs_navigator/staff_portal/mdes/version_migrator_spec.rb
+++ b/spec/lib/ncs_navigator/staff_portal/mdes/version_migrator_spec.rb
@@ -1,0 +1,134 @@
+require 'spec_helper'
+
+module NcsNavigator::StaffPortal::Mdes
+  describe VersionMigrator do
+    def dummy_migration(from, to)
+      stub("dummy_migration #{from} -> #{to}").tap do |m|
+        m.stub!(:from => from, :to => to)
+      end
+    end
+
+    describe '#initialize' do
+      before do
+      	StaffPortal.stub!(:mdes_version => MdesVersion.new('1.1'))
+        # NcsNavigatorCore.stub!(:mdes_version => Version.new('1.1'))
+      end
+
+      describe ':start_version' do
+        it 'can be set' do
+          VersionMigrator.new(:start_version => '7.8').start_version.should == '7.8'
+        end
+
+        it 'defaults to the current deployed version' do
+          VersionMigrator.new.start_version.should == '1.1'
+        end
+      end
+
+      describe ':known_migrations' do
+        it 'can be set' do
+          VersionMigrator.new(:known_migrations => [dummy_migration('3', 'forks'), dummy_migration('tacos', '8')]).
+            known_migrations.collect(&:from).should == %w(3 tacos)
+        end
+
+        it 'defaults to the KNOWN_MIGRATIONS constant' do
+          VersionMigrator.new.known_migrations.should be(VersionMigrator::KNOWN_MIGRATIONS)
+        end
+      end
+    end
+
+    describe '#migrations' do
+      let(:known_migrations) {
+        [
+          dummy_migration('8.0', '8.1'),
+          dummy_migration('8.1', '8.2'),
+          dummy_migration('8.2', '8.3'),
+          dummy_migration('8.3', '9.0'),
+          dummy_migration('8.1', '9.0'),
+          dummy_migration('9.0', '9.1'),
+          dummy_migration('9.0', '9.2'),
+          dummy_migration('9.1', '9.2'),
+          dummy_migration('9.1', '10.0'),
+          dummy_migration('9.5', '11.0'),
+        ]
+      }
+
+      let(:options) {
+        { :known_migrations => known_migrations, :start_version => '8.1' }
+      }
+
+      let(:migrator) {
+        VersionMigrator.new(options)
+      }
+
+      def series_string(target_version)
+        migrator.migrations(target_version).collect { |m| [m.from, m.to].join(" -> ") }.join(", ")
+      end
+
+      it 'can find a single migration that matches the request' do
+        series_string('9.0').should == "8.1 -> 9.0"
+      end
+
+      it 'can find a migration chain that requires several migrations' do
+        series_string('8.3').should == "8.1 -> 8.2, 8.2 -> 8.3"
+      end
+
+      it 'picks the shortest path when there are several options' do
+        series_string('9.2').should == "8.1 -> 9.0, 9.0 -> 9.2"
+      end
+
+      it 'throws an exception if there is no migration chain because the target version does not exist' do
+        expect { migrator.migrations('9.3') }.to raise_error("There is no migration path to 9.3 from any version.")
+      end
+
+      it 'throws an exception if there is no migration chain because there is a missing link' do
+        expect { migrator.migrations('11.0') }.to raise_error("There is no migration path from 8.1 to 11.0.")
+      end
+
+      it 'throws an exception if there is no migration chain because the start version does not exist' do
+        options[:start_version] = '8.5'
+
+        expect { migrator.migrations('9.0') }.to raise_error("There is no migration path from 8.5 to any version.")
+      end
+    end
+
+    describe '#migrate!' do
+      let(:known_migrations) {
+        [
+          dummy_migration('8.0', '8.1'),
+          dummy_migration('8.1', '8.2'),
+          m82_83,
+          m83_90,
+          dummy_migration('8.1', '9.0'),
+          m90_91,
+          dummy_migration('9.0', '9.2'),
+          dummy_migration('9.1', '9.2'),
+          dummy_migration('9.1', '10.0'),
+          dummy_migration('9.5', '11.0'),
+        ]
+      }
+
+      let(:options) {
+        { :known_migrations => known_migrations, :start_version => '8.2' }
+      }
+
+      let(:migrator) {
+        VersionMigrator.new(options)
+      }
+
+      let(:m82_83) { dummy_migration('8.2', '8.3') }
+      let(:m83_90) { dummy_migration('8.3', '9.0') }
+      let(:m90_91) { dummy_migration('9.0', '9.1') }
+
+      let(:expected_used_migrations) { [m82_83, m83_90, m90_91] }
+
+      it 'runs exactly the appropriate migrations' do
+        # RSpec mocks can't verify order across objects, so this will have to be
+        # good enough.
+        expected_used_migrations.each { |m| m.should_receive(:run) }
+        (known_migrations - expected_used_migrations).each { |m| m.should_not_receive(:run) }
+
+        migrator.migrate!('9.1')
+      end
+    end
+  end
+end


### PR DESCRIPTION
This commits add infrastructure for migrating from one mdes version to other mdes version.
Also register MDES 3.0 to MDES 3.2 migration.
